### PR TITLE
Require webpki 0.9.2; bump version to 0.6.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-roots"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 readme = "README.md"
 license = "MPL-2.0"
@@ -10,4 +10,4 @@ repository = "https://github.com/ctz/webpki-roots"
 
 [dependencies]
 untrusted = "0.3"
-webpki = "0.8.0"
+webpki = "0.9.2"


### PR DESCRIPTION
webpki 0.9.2 depends on *ring* 0.6.3, which contains a possible
security fix.