### PR TITLE
0.10.0: Use webpki 0.12.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-roots"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 readme = "README.md"
 license = "MPL-2.0"
@@ -10,4 +10,4 @@ repository = "https://github.com/ctz/webpki-roots"
 
 [dependencies]
 untrusted = "0.5"
-webpki = "0.11"
+webpki = "0.12"


### PR DESCRIPTION
This is required in order to update Rustls to use *ring* 0.9.