### PR TITLE
0.22.0: Upgrade to webpki 0.22.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-roots"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 readme = "README.md"
@@ -10,4 +10,4 @@ homepage = "https://github.com/ctz/webpki-roots"
 repository = "https://github.com/ctz/webpki-roots"
 
 [dependencies]
-webpki = "0.21.0"
+webpki = "0.22.0"

--- a/src/bin/process_cert.rs
+++ b/src/bin/process_cert.rs
@@ -15,7 +15,7 @@ fn main() {
   io::stdin().read_to_end(&mut der)
     .expect("cannot read stdin");
 
-  let ta = webpki::trust_anchor_util::cert_der_as_trust_anchor(&der)
+  let ta = webpki::TrustAnchor::try_from_cert_der(&der)
     .expect("cannot parse certificate");
 
   dumphex("Subject", ta.subject);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
         unused_extern_crates,
         unused_qualifications)]
 
-pub static TLS_SERVER_ROOTS: webpki::TLSServerTrustAnchors = webpki::TLSServerTrustAnchors(&[
+pub static TLS_SERVER_ROOTS: webpki::TlsServerTrustAnchors = webpki::TlsServerTrustAnchors(&[
   /*
    * Issuer: CN=Entrust Root Certification Authority - EC1 O=Entrust, Inc. OU=See www.entrust.net/legal-terms/(c) 2012 Entrust, Inc. - for authorized use only
    * Subject: CN=Entrust Root Certification Authority - EC1 O=Entrust, Inc. OU=See www.entrust.net/legal-terms/(c) 2012 Entrust, Inc. - for authorized use only


### PR DESCRIPTION
webpki contains breaking API changes. The one that affects webpki-roots is
the change to use Rust naming conventions.